### PR TITLE
Add new field to enter your own uID

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,9 @@ function App() {
   const [did, setDid] = useState<string | undefined>();
   const [network, setNetwork] = useState<string | undefined>();
   const [error, setInternalError] = useState<Error | undefined>();
-  const [ticker, setTicker] = useState<string>('')
+  const [ticker, setTicker] = useState<string>('');
+  const [uid, setUid] = useState<string>('');
+  
 
   const setError = (error: Error, disappear: boolean = false) => {
     setInternalError(error);
@@ -29,6 +31,7 @@ function App() {
     setProof('');
     setInternalError(undefined);
     setTicker('');
+    setUid('');
   }
 
   const _setAddress = async (address: string) => {
@@ -130,7 +133,22 @@ function App() {
     setTicker(event.target.value);
   }
 
-  const provideUid = async (polyWallet: any, did: string) => {
+  const handleUidChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    setUid(event.target.value);
+  }
+
+  const provideUid = async (polyWallet: any, did: string, uid: string) => {
+    console.log('>>> uid', uid);
+
+    polyWallet.uid.provide({
+      uid,
+      did,
+      network
+    }).then(console.log, setDisappearingError).catch(setDisappearingError);
+  }
+
+  const provideUidFromDid = async (polyWallet: any, did: string) => {
     console.log('Generating uID...');
     const crypto = await import('@polymathnetwork/confidential-identity')
     const mockUIdHex = `0x${crypto.process_create_mocked_investor_uid(did)}`;
@@ -160,9 +178,13 @@ function App() {
           </p>
           { did && 
           <>
-            <button  onClick={() => provideUid(polyWallet, did)}>
+            <button  onClick={() => provideUidFromDid(polyWallet, did)}>
             Generate a dummy uID and import it to Polymesh wallet
             </button> 
+            <p>
+              <input name='uid' value={uid} type='text' onChange={handleUidChange} />
+              <button onClick={() => provideUid(polyWallet, did, uid)}>Enter uID and import it to Polymesh wallet</button>
+            </p>
             <p>
               <input name='ticker' value={ticker} type='text' onChange={handleChange} />
               <button onClick={() => generateProof(polyWallet)}>Use stored uID to generate proof</button>


### PR DESCRIPTION
This will be useful when testing around ITN where we can't assume deterministic uIDs (i.e. using `crypto.process_create_mocked_investor_uid`)